### PR TITLE
고정지출 목록 정렬 및 화면 흐름 개선

### DIFF
--- a/src/features/common/components/fixedExpenseList/index.tsx
+++ b/src/features/common/components/fixedExpenseList/index.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from "react";
 
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { useUserStore } from "@/features/auth/store";
@@ -12,7 +12,7 @@ import {
   useToggleFixedExpensePaymentMutation,
 } from "@/features/common/queries";
 import { FixedItem } from "@/features/common/types";
-import { Button, Column, Empty, Text } from "@/shared/ui";
+import { Button, Column, Empty, Row, Text } from "@/shared/ui";
 import { getFixedExpenseDueDate } from "@/shared/utils/date";
 import { safeLocalStorage } from "@/shared/utils/storage";
 
@@ -133,16 +133,19 @@ export default function FixedExpenseList() {
         )}
         <Button
           onClick={handleAddClick}
-          width={70}
-          height={36}
+          width={84}
+          height={44}
           variant="fill"
           size="s"
           radius="pill"
           aria-label="고정지출 추가"
         >
-          <Text size={14} weight={600} color="inverseWhite">
-            추가
-          </Text>
+          <Row gap={6} align="center">
+            <Plus size={16} aria-hidden />
+            <Text size={14} weight={600} color="inverseWhite">
+              추가
+            </Text>
+          </Row>
         </Button>
       </S.ListActions>
 

--- a/src/features/common/components/fixedExpenseList/index.tsx
+++ b/src/features/common/components/fixedExpenseList/index.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from "react";
 
-import { ChevronDown, Plus } from "lucide-react";
+import { ArrowDown, ArrowUp, ChevronDown, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { useUserStore } from "@/features/auth/store";
@@ -20,22 +20,24 @@ import FixedExpenseListScreenSkeleton from "./skeleton";
 import * as S from "./style";
 
 const SORT_STORAGE_KEY = "fixed-expense-sort";
+const SORT_DIRECTION_STORAGE_KEY = "fixed-expense-sort-direction";
 const SORT_OPTIONS = [
-  { value: "dueDate", label: "납부일 빠른순" },
-  { value: "amountDesc", label: "금액 높은순" },
-  { value: "amountAsc", label: "금액 낮은순" },
-  { value: "tag", label: "태그 가나다순" },
+  { value: "dueDate", label: "납부일순" },
+  { value: "amount", label: "금액순" },
+  { value: "tag", label: "태그순" },
 ] as const;
-type FixedExpenseSort = (typeof SORT_OPTIONS)[number]["value"];
+type FixedExpenseSortCriterion = (typeof SORT_OPTIONS)[number]["value"];
+type FixedExpenseSortDirection = "asc" | "desc";
 
-const isFixedExpenseSort = (value: string | null): value is FixedExpenseSort => {
+const isFixedExpenseSortCriterion = (value: string | null): value is FixedExpenseSortCriterion => {
   return SORT_OPTIONS.some((option) => option.value === value);
 };
 
 export default function FixedExpenseList() {
   const router = useRouter();
   const userId = useUserStore((state) => state.userId);
-  const [sort, setSort] = useState<FixedExpenseSort>("dueDate");
+  const [sortCriterion, setSortCriterion] = useState<FixedExpenseSortCriterion>("dueDate");
+  const [sortDirection, setSortDirection] = useState<FixedExpenseSortDirection>("asc");
 
   const { data, isFetched } = useFixedExpenseTableQuery(userId);
   const dueDates = getFixedExpenseDueDates(data?.items);
@@ -43,21 +45,28 @@ export default function FixedExpenseList() {
   const { mutate: togglePaid } = useToggleFixedExpensePaymentMutation(dueDates);
 
   useEffect(() => {
-    const storedSort = safeLocalStorage.getItem(SORT_STORAGE_KEY);
-    if (isFixedExpenseSort(storedSort)) setSort(storedSort);
+    const storedCriterion = safeLocalStorage.getItem(SORT_STORAGE_KEY);
+    const storedDirection = safeLocalStorage.getItem(SORT_DIRECTION_STORAGE_KEY);
+
+    if (isFixedExpenseSortCriterion(storedCriterion)) setSortCriterion(storedCriterion);
+    if (storedDirection === "asc" || storedDirection === "desc") setSortDirection(storedDirection);
   }, []);
 
   const sortedItems = [...(data?.items ?? [])].sort((a, b) => {
-    switch (sort) {
-      case "amountDesc":
-        return b.amount - a.amount;
-      case "amountAsc":
-        return a.amount - b.amount;
+    let comparison: number;
+
+    switch (sortCriterion) {
+      case "amount":
+        comparison = a.amount - b.amount;
+        break;
       case "tag":
-        return a.tag.localeCompare(b.tag, "ko");
+        comparison = a.tag.localeCompare(b.tag, "ko");
+        break;
       default:
-        return getFixedExpenseDueDate(a).localeCompare(getFixedExpenseDueDate(b));
+        comparison = getFixedExpenseDueDate(a).localeCompare(getFixedExpenseDueDate(b));
     }
+
+    return sortDirection === "asc" ? comparison : -comparison;
   });
 
   const hasItems = sortedItems.length > 0;
@@ -79,11 +88,17 @@ export default function FixedExpenseList() {
   };
 
   const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const nextSort = event.target.value;
-    if (!isFixedExpenseSort(nextSort)) return;
+    const nextCriterion = event.target.value;
+    if (!isFixedExpenseSortCriterion(nextCriterion)) return;
 
-    setSort(nextSort);
-    safeLocalStorage.setItem(SORT_STORAGE_KEY, nextSort);
+    setSortCriterion(nextCriterion);
+    safeLocalStorage.setItem(SORT_STORAGE_KEY, nextCriterion);
+  };
+
+  const handleSortDirectionClick = () => {
+    const nextDirection = sortDirection === "asc" ? "desc" : "asc";
+    setSortDirection(nextDirection);
+    safeLocalStorage.setItem(SORT_DIRECTION_STORAGE_KEY, nextDirection);
   };
 
   const handleTogglePaid = (item: FixedItem) => {
@@ -119,17 +134,35 @@ export default function FixedExpenseList() {
 
       <S.ListActions $hasItems={hasItems}>
         {hasItems && (
-          <S.SortControl>
-            <span>{SORT_OPTIONS.find((option) => option.value === sort)?.label}</span>
-            <ChevronDown size={14} aria-hidden />
-            <S.SortSelect value={sort} onChange={handleSortChange} aria-label="고정지출 정렬">
-              {SORT_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </S.SortSelect>
-          </S.SortControl>
+          <Row gap={8} align="center">
+            <S.SortControl>
+              <span>{SORT_OPTIONS.find((option) => option.value === sortCriterion)?.label}</span>
+              <ChevronDown size={14} aria-hidden />
+              <S.SortSelect value={sortCriterion} onChange={handleSortChange} aria-label="고정지출 정렬 기준">
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </S.SortSelect>
+            </S.SortControl>
+            <Button
+              onClick={handleSortDirectionClick}
+              width={44}
+              height={44}
+              variant="outline"
+              color="secondary"
+              size="s"
+              radius="pill"
+              aria-label={sortDirection === "asc" ? "내림차순으로 변경" : "오름차순으로 변경"}
+            >
+              {sortDirection === "asc" ? (
+                <ArrowUp size={16} aria-hidden />
+              ) : (
+                <ArrowDown size={16} aria-hidden />
+              )}
+            </Button>
+          </Row>
         )}
         <Button
           onClick={handleAddClick}

--- a/src/features/common/components/fixedExpenseList/index.tsx
+++ b/src/features/common/components/fixedExpenseList/index.tsx
@@ -1,3 +1,6 @@
+import { ChangeEvent, useEffect, useState } from "react";
+
+import { ChevronDown } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { useUserStore } from "@/features/auth/store";
@@ -9,22 +12,55 @@ import {
   useToggleFixedExpensePaymentMutation,
 } from "@/features/common/queries";
 import { FixedItem } from "@/features/common/types";
-import { Button, Column, Empty, Row, Text } from "@/shared/ui";
+import { Button, Column, Empty, Text } from "@/shared/ui";
 import { getFixedExpenseDueDate } from "@/shared/utils/date";
+import { safeLocalStorage } from "@/shared/utils/storage";
 
 import FixedExpenseListScreenSkeleton from "./skeleton";
 import * as S from "./style";
 
+const SORT_STORAGE_KEY = "fixed-expense-sort";
+const SORT_OPTIONS = [
+  { value: "dueDate", label: "납부일 빠른순" },
+  { value: "amountDesc", label: "금액 높은순" },
+  { value: "amountAsc", label: "금액 낮은순" },
+  { value: "tag", label: "태그 가나다순" },
+] as const;
+type FixedExpenseSort = (typeof SORT_OPTIONS)[number]["value"];
+
+const isFixedExpenseSort = (value: string | null): value is FixedExpenseSort => {
+  return SORT_OPTIONS.some((option) => option.value === value);
+};
+
 export default function FixedExpenseList() {
   const router = useRouter();
   const userId = useUserStore((state) => state.userId);
+  const [sort, setSort] = useState<FixedExpenseSort>("dueDate");
 
   const { data, isFetched } = useFixedExpenseTableQuery(userId);
   const dueDates = getFixedExpenseDueDates(data?.items);
   const { data: payments = [] } = useFixedExpensePaymentsQuery(userId, data?.items);
   const { mutate: togglePaid } = useToggleFixedExpensePaymentMutation(dueDates);
 
-  const hasItems = (data?.items?.length ?? 0) > 0;
+  useEffect(() => {
+    const storedSort = safeLocalStorage.getItem(SORT_STORAGE_KEY);
+    if (isFixedExpenseSort(storedSort)) setSort(storedSort);
+  }, []);
+
+  const sortedItems = [...(data?.items ?? [])].sort((a, b) => {
+    switch (sort) {
+      case "amountDesc":
+        return b.amount - a.amount;
+      case "amountAsc":
+        return a.amount - b.amount;
+      case "tag":
+        return a.tag.localeCompare(b.tag, "ko");
+      default:
+        return getFixedExpenseDueDate(a).localeCompare(getFixedExpenseDueDate(b));
+    }
+  });
+
+  const hasItems = sortedItems.length > 0;
   const totalAmount = data?.totalFixedExpense ?? 0;
   const paidKeys = new Set(payments.map((payment) => `${payment.fixedItemCreatedAt}:${payment.dueDate}`));
   const remainingAmount =
@@ -40,6 +76,14 @@ export default function FixedExpenseList() {
 
   const handleAddClick = () => {
     router.push("/dashboard/fixed/new");
+  };
+
+  const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextSort = event.target.value;
+    if (!isFixedExpenseSort(nextSort)) return;
+
+    setSort(nextSort);
+    safeLocalStorage.setItem(SORT_STORAGE_KEY, nextSort);
   };
 
   const handleTogglePaid = (item: FixedItem) => {
@@ -60,26 +104,9 @@ export default function FixedExpenseList() {
 
   return (
     <S.ListScreenContainer>
-      <Row justify="space-between" align="center" fullWidth>
-        <Text size={24} weight={700}>
-          고정지출
-        </Text>
-        <Button
-          onClick={handleAddClick}
-          width={70}
-          height={36}
-          variant="fill"
-          size="s"
-          radius="pill"
-          aria-label="고정지출 추가"
-        >
-          <Row gap={5} align="center">
-            <Text size={14} weight={600} color="inverseWhite">
-              추가
-            </Text>
-          </Row>
-        </Button>
-      </Row>
+      <Text size={24} weight={700}>
+        고정지출
+      </Text>
 
       {totalAmount > 0 && (
         <Column gap={2}>
@@ -90,9 +117,38 @@ export default function FixedExpenseList() {
         </Column>
       )}
 
+      <S.ListActions $hasItems={hasItems}>
+        {hasItems && (
+          <S.SortControl>
+            <span>{SORT_OPTIONS.find((option) => option.value === sort)?.label}</span>
+            <ChevronDown size={14} aria-hidden />
+            <S.SortSelect value={sort} onChange={handleSortChange} aria-label="고정지출 정렬">
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </S.SortSelect>
+          </S.SortControl>
+        )}
+        <Button
+          onClick={handleAddClick}
+          width={70}
+          height={36}
+          variant="fill"
+          size="s"
+          radius="pill"
+          aria-label="고정지출 추가"
+        >
+          <Text size={14} weight={600} color="inverseWhite">
+            추가
+          </Text>
+        </Button>
+      </S.ListActions>
+
       {hasItems ? (
-        <S.ListBox $hasItems={hasItems}>
-          {data?.items?.map((item) => {
+        <S.ListBox>
+          {sortedItems.map((item) => {
             const dueDate = getFixedExpenseDueDate(item);
             const isPaid = paidKeys.has(`${item.createdAt}:${dueDate}`);
 

--- a/src/features/common/components/fixedExpenseList/index.tsx
+++ b/src/features/common/components/fixedExpenseList/index.tsx
@@ -83,7 +83,7 @@ export default function FixedExpenseList() {
 
       {totalAmount > 0 && (
         <Column gap={2}>
-          <SlotCounter value={totalAmount} fontSize={24} suffix="원" />
+          <SlotCounter value={totalAmount} animationKey={`fixed-expense-total:${userId}`} fontSize={24} suffix="원" />
           <Text size={13} weight={600} color={remainingAmount > 0 ? "secondary" : "darkBlue"}>
             {remainingAmount > 0 ? `잔여 납부 금액 ${remainingAmount.toLocaleString()}원` : "이번 회차 납부 완료"}
           </Text>

--- a/src/features/common/components/fixedExpenseList/style.ts
+++ b/src/features/common/components/fixedExpenseList/style.ts
@@ -19,14 +19,6 @@ export const ListActions = styled.div<{ $hasItems: boolean }>`
   display: flex;
   align-items: center;
   justify-content: ${({ $hasItems }) => ($hasItems ? "space-between" : "flex-end")};
-
-  > button:last-child:active::after {
-    opacity: 0;
-  }
-
-  > button:last-child:active:not(:disabled) {
-    transform: none;
-  }
 `;
 
 export const SortControl = styled.label`

--- a/src/features/common/components/fixedExpenseList/style.ts
+++ b/src/features/common/components/fixedExpenseList/style.ts
@@ -19,12 +19,20 @@ export const ListActions = styled.div<{ $hasItems: boolean }>`
   display: flex;
   align-items: center;
   justify-content: ${({ $hasItems }) => ($hasItems ? "space-between" : "flex-end")};
+
+  > button:last-child:active::after {
+    opacity: 0;
+  }
+
+  > button:last-child:active:not(:disabled) {
+    transform: none;
+  }
 `;
 
 export const SortControl = styled.label`
   position: relative;
   align-self: flex-start;
-  min-height: 36px;
+  min-height: 44px;
   padding: 0 12px;
   display: inline-flex;
   align-items: center;

--- a/src/features/common/components/fixedExpenseList/style.ts
+++ b/src/features/common/components/fixedExpenseList/style.ts
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import { Column } from "@/shared/ui";
 
@@ -8,16 +8,49 @@ export const ListScreenContainer = styled(Column)`
   padding-bottom: calc(110px + env(safe-area-inset-bottom));
 `;
 
-export const ListBox = styled(Column)<{ $hasItems: boolean }>`
+export const ListBox = styled(Column)`
   gap: 10px;
   align-self: stretch;
   padding-bottom: 12px;
+`;
 
-  ${({ $hasItems }) =>
-    $hasItems &&
-    css`
-      padding-bottom: 12px;
-    `}
+export const ListActions = styled.div<{ $hasItems: boolean }>`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: ${({ $hasItems }) => ($hasItems ? "space-between" : "flex-end")};
+`;
+
+export const SortControl = styled.label`
+  position: relative;
+  align-self: flex-start;
+  min-height: 36px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid ${({ theme }) => theme.colors.border.secondary};
+  border-radius: ${({ theme }) => theme.radius.pill};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  background: ${({ theme }) => theme.colors.bg.inverseWhite};
+  font-size: 13px;
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  cursor: pointer;
+
+  &:focus-within {
+    border-color: ${({ theme }) => theme.colors.border.primary};
+    box-shadow: ${({ theme }) => theme.shadows.focusRing};
+  }
+`;
+
+export const SortSelect = styled.select`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  font-size: 16px;
+  cursor: pointer;
 `;
 
 export const EmptyState = styled(Column)`

--- a/src/features/common/components/slotCounter/SlotCounter.tsx
+++ b/src/features/common/components/slotCounter/SlotCounter.tsx
@@ -10,8 +10,11 @@ import { formatWithComma } from "@/shared/utils/formatter";
 
 import DigitReel from "./DigitReel";
 
+const lastAnimatedValues = new Map<string, number>();
+
 type SlotCounterProps = {
   value: number;
+  animationKey?: string;
   duration?: number; // 전체 애니메이션 시간
   spins?: number; // 최소 회전 바퀴 수
   fontSize?: number;
@@ -22,6 +25,7 @@ type SlotCounterProps = {
 
 export default function SlotCounter({
   value,
+  animationKey,
   duration = 1.2,
   spins = 1,
   fontSize = 28,
@@ -29,12 +33,13 @@ export default function SlotCounter({
   lineHeightFactor = 1.2,
   color = "primary",
 }: SlotCounterProps) {
-  const prevValueRef = useRef<number | null>(null);
+  const prevValueRef = useRef<number | null>(animationKey ? (lastAnimatedValues.get(animationKey) ?? null) : null);
   const prevValue = prevValueRef.current;
 
   useEffect(() => {
     prevValueRef.current = value;
-  }, [value]);
+    if (animationKey) lastAnimatedValues.set(animationKey, value);
+  }, [animationKey, value]);
 
   const formatted = useMemo(() => formatWithComma(value), [value]);
 
@@ -63,7 +68,7 @@ export default function SlotCounter({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 10, filter: "blur(4px)" }}
+      initial={prevValue === null ? { opacity: 0, y: 10, filter: "blur(4px)" } : false}
       animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
       transition={{ duration: 0.8, ease: "easeOut" }}
     >

--- a/src/shared/layout/bottomNavigation/index.tsx
+++ b/src/shared/layout/bottomNavigation/index.tsx
@@ -3,11 +3,11 @@
 import { useRef, useState } from "react";
 
 import { type PanInfo, motion } from "framer-motion";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { DashboardTab, useDashboardTabStore } from "@/features/dashboard/home/store";
 import { FixedIcon, HistoryIcon, HomeIcon } from "@/shared/assets/svg/interface";
-import { navigateToDashboardTab } from "@/shared/lib/navigation/dashboard";
+import { dashboardTabPath } from "@/shared/lib/navigation/dashboard";
 
 import * as S from "./style";
 
@@ -19,6 +19,7 @@ const NAV_ITEMS: { tab: DashboardTab; label: string; icon: typeof HomeIcon }[] =
 
 export default function BottomNavigation() {
   const pathname = usePathname();
+  const router = useRouter();
   const navInnerRef = useRef<HTMLDivElement | null>(null);
   const navItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [previewTab, setPreviewTab] = useState<DashboardTab | null>(null);
@@ -29,11 +30,16 @@ export default function BottomNavigation() {
 
   if (!isDashboard) return null;
 
+  const handleTabChange = (tab: DashboardTab) => {
+    setActiveTab(tab);
+    window.scrollTo({ top: 0, behavior: "instant" });
+    router.replace(dashboardTabPath(tab), { scroll: false });
+  };
+
   const handleTabClick = (tab: DashboardTab) => {
     if (tab === activeTab) return;
     setPreviewTab(null);
-    setActiveTab(tab);
-    navigateToDashboardTab(tab);
+    handleTabChange(tab);
   };
 
   const getNearestTabFromX = (targetX: number) => {
@@ -56,8 +62,7 @@ export default function BottomNavigation() {
 
     if (!nearestTab || nearestTab === activeTab) return;
 
-    setActiveTab(nearestTab);
-    navigateToDashboardTab(nearestTab);
+    handleTabChange(nearestTab);
   };
 
   const visualActiveTab = previewTab ?? activeTab;

--- a/src/shared/layout/bottomNavigation/style.ts
+++ b/src/shared/layout/bottomNavigation/style.ts
@@ -3,11 +3,11 @@ import styled from "styled-components";
 
 export const NavContainer = styled.nav`
   position: fixed;
-  bottom: 6px;
+  bottom: 15px;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
-  max-width: 500px;
+  width: max-content;
+  max-width: calc(100vw - 24px);
   padding: 6px 16px max(8px, env(safe-area-inset-bottom, 0px));
   z-index: 100;
 `;
@@ -18,7 +18,7 @@ export const NavInner = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
+  width: max-content;
   gap: 4px;
   padding: 4px;
   border: 1px solid light-dark(rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0.13));
@@ -86,7 +86,7 @@ export const NavInner = styled.div`
 
 export const NavItem = styled(motion.button)<{ $isActive: boolean }>`
   position: relative;
-  flex: 1;
+  flex: 0 0 88px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/shared/layout/dashboardHeader/index.tsx
+++ b/src/shared/layout/dashboardHeader/index.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import Logo from "@/shared/assets/images/soomtong.png";
 import { SingleArrowIcon } from "@/shared/assets/svg/interface";
-import { Heading, Row } from "@/shared/ui";
+import { Row } from "@/shared/ui";
 
-// 뒤로가기 버튼이 필요한 탭
 const SUB_TABS = ["expense-analysis"];
 
 export default function DashboardHeader() {
@@ -19,21 +16,13 @@ export default function DashboardHeader() {
   const currentTab = searchParams.get("tab") || "home";
   const isSubTab = SUB_TABS.includes(currentTab);
 
+  if (isDashboardRoot && !isSubTab) return null;
+
   return (
     <Row align="center" justify="space-between">
-      {(!isDashboardRoot || isSubTab) && (
-        <button type="button" onClick={() => router.back()}>
-          <SingleArrowIcon size={40} />
-        </button>
-      )}
-      {isDashboardRoot && !isSubTab && (
-        <Row gap={4} align="center">
-          <Image src={Logo} width={40} height={40} alt="Soomtong Logo" priority />
-          <Heading level={3} fontWeight="bold">
-            Soomtong
-          </Heading>
-        </Row>
-      )}
+      <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
+        <SingleArrowIcon size={40} />
+      </button>
     </Row>
   );
 }

--- a/src/shared/lib/navigation/dashboard.ts
+++ b/src/shared/lib/navigation/dashboard.ts
@@ -12,10 +12,3 @@ export function isDashboardFormPath(pathname: string) {
     /^\/dashboard\/fixed\/[^/]+\/edit$/.test(pathname)
   );
 }
-
-export function navigateToDashboardTab(tab: DashboardTab) {
-  window.scrollTo({ top: 0, behavior: "instant" });
-  const newUrl = new URL(window.location.href);
-  newUrl.searchParams.set("tab", tab);
-  window.history.replaceState({}, "", newUrl.toString());
-}

--- a/src/shared/ui/button/style.ts
+++ b/src/shared/ui/button/style.ts
@@ -108,7 +108,6 @@ export const Button = styled.button<ButtonStyleProps>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  position: relative;
 
   font-weight: ${({ theme }) => theme.fontWeight.medium};
 
@@ -120,27 +119,9 @@ export const Button = styled.button<ButtonStyleProps>`
   -webkit-appearance: none;
   appearance: none;
   transition:
-    transform 0.12s ease,
     filter 0.12s ease,
     background-color 0.2s ease,
     border-color 0.2s ease;
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: var(--color-pressed-overlay);
-    opacity: 0;
-    transition: opacity 0.08s ease-out;
-  }
-
-  &:active::after {
-    opacity: 1;
-  }
-
-  &:active:not(:disabled) {
-    transform: scale(0.98);
-  }
 
   ${({ $size }) => sizeStyles[$size]}
   ${({ $radius = "md" }) => radiusStyles[$radius]}

--- a/src/widgets/fixedExpenseFormScreen/index.tsx
+++ b/src/widgets/fixedExpenseFormScreen/index.tsx
@@ -16,7 +16,6 @@ import { FixedItem } from "@/features/common/types";
 import { TrashIcon } from "@/shared/assets/svg/interface";
 import { FIXED_EXPENSE_CATEGORY_LIST } from "@/shared/config";
 import FormScreen from "@/shared/layout/formScreen";
-import { dashboardTabPath } from "@/shared/lib/navigation/dashboard";
 import { Alert, Button, Column, Empty, Heading, Input, Skeleton } from "@/shared/ui";
 import { formatWithComma, parseNumericInput } from "@/shared/utils/formatter";
 
@@ -75,12 +74,11 @@ export default function FixedExpenseFormScreen({ mode, createdAt }: Props) {
     setIsInitialized(true);
   }, [isInitialized, item, mode]);
 
-  const destination = dashboardTabPath("fixed");
   const isDirty = isInitialized && JSON.stringify(values) !== JSON.stringify(initialValues);
   const isSubmitting = addMutation.isPending || updateMutation.isPending || removeMutation.isPending;
   const isSubmitDisabled = !userId || !isInitialized || !values.tag || parseNumericInput(values.amount) < 1;
 
-  const handleLeave = () => router.replace(destination);
+  const handleLeave = () => router.back();
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -92,7 +90,7 @@ export default function FixedExpenseFormScreen({ mode, createdAt }: Props) {
       day: values.day,
       memo: values.memo,
     };
-    const options = { onSuccess: () => router.replace(destination) };
+    const options = { onSuccess: handleLeave };
 
     if (mode === "edit") {
       updateMutation.mutate({ userId, createdAt, item: { ...nextItem, createdAt } }, options);
@@ -105,10 +103,7 @@ export default function FixedExpenseFormScreen({ mode, createdAt }: Props) {
   const handleDelete = () => {
     if (!item || removeMutation.isPending) return;
 
-    removeMutation.mutate(
-      { userId, tag: item.tag, createdAt: item.createdAt },
-      { onSuccess: () => router.replace(destination) },
-    );
+    removeMutation.mutate({ userId, tag: item.tag, createdAt: item.createdAt }, { onSuccess: handleLeave });
   };
 
   if (isMissing) {

--- a/src/widgets/fixedExpenseFormScreen/index.tsx
+++ b/src/widgets/fixedExpenseFormScreen/index.tsx
@@ -63,7 +63,7 @@ export default function FixedExpenseFormScreen({ mode, createdAt }: Props) {
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
 
   const item = mode === "edit" ? data?.items?.find((candidate) => candidate.createdAt === createdAt) : undefined;
-  const isMissing = mode === "edit" && isFetched && !item;
+  const isMissing = mode === "edit" && isFetched && !removeMutation.isPending && !item;
 
   useEffect(() => {
     if (mode !== "edit" || !item || isInitialized) return;

--- a/src/widgets/homeScreen/index.tsx
+++ b/src/widgets/homeScreen/index.tsx
@@ -20,7 +20,14 @@ export default function HomeScreen() {
   if (showLogoLoading) {
     return (
       <Column height="100%" flex={1} align="center" justify="center">
-        <Image src={Logo} width={120} height={120} alt="Soomtong Logo" priority />
+        <Image
+          src={Logo}
+          width={120}
+          height={120}
+          alt="Soomtong Logo"
+          priority
+          style={{ filter: "brightness(0) invert(1)" }}
+        />
       </Column>
     );
   }


### PR DESCRIPTION
## 변경 사항

  - 고정지출 목록 정렬 및 오름/내림차순 전환 기능 추가
  - 고정지출 수정/삭제 후 이전 탭과 화면 상태가 유지되도록 개선
  - 고정지출 추가 버튼, 하단 네비게이션, 대시보드 헤더 UI 개선

  ## 영향

  고정지출을 더 쉽게 정렬/관리할 수 있고, 수정 후 목록 탐색 흐름이 자연스럽게 이어짐